### PR TITLE
Update docs

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@ PORT=8103
 FLASK_DEBUG=true
 SECRET_KEY=secret_key
 DEVEL=True
+OPENID_LAUNCHPAD_TEAM=canonical-content-people

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -11,6 +11,16 @@ env:
       key: releases-github-token
       name: github-api
 
+  - name: DISCOURSE_API_KEY
+    secretKeyRef:
+      key: discourse_api_key
+      name: canonical-discourse
+
+  - name: DISCOURSE_API_USERNAME
+    secretKeyRef:
+      key: discourse-api-username
+      name: canonical-discourse
+
 memoryLimit: 128Mi
 
 # Overrides for production

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ canonicalwebteam.flask-base==0.9.3
 canonicalwebteam.discourse==4.0.8
 humanize==3.13.1
 launchpadlib==1.10.15.1
+django-openid-auth==0.16
+Flask-OpenID==1.3.0

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,7 +1,8 @@
 import flask
 from canonicalwebteam.flask_base.app import FlaskBase
 
-from webapp.guides import discourse_docs
+from webapp.guides import init_docs
+from webapp.sso import init_sso
 from webapp.team import webteam
 from webapp.releases import releases
 from webapp.canonicool import canonicool
@@ -22,4 +23,5 @@ def index():
 app.register_blueprint(webteam, url_prefix="/team")
 app.register_blueprint(releases, url_prefix="/releases")
 app.register_blueprint(canonicool, url_prefix="/canonicool")
-discourse_docs.init_app(app)
+init_docs(app)
+init_sso(app)

--- a/webapp/guides.py
+++ b/webapp/guides.py
@@ -1,18 +1,34 @@
+import os
+from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
+import flask
+
 import talisker.requests
 
-from canonicalwebteam.discourse import DiscourseAPI, DocParser, Docs
+DISCOURSE_INDEX_TOPIC = 157
+DISCOURSE_API_KEY = os.getenv("DISCOURSE_API_KEY")
+DISCOURSE_API_USERNAME = os.getenv("DISCOURSE_API_USERNAME")
 
-discourse_index_id = 14129
 
-session = talisker.requests.get_session()
-discourse_docs = Docs(
-    parser=DocParser(
-        api=DiscourseAPI(
-            base_url="https://discourse.ubuntu.com/", session=session
+def init_docs(app):
+    session = talisker.requests.get_session()
+    discourse_docs = Docs(
+        parser=DocParser(
+            api=DiscourseAPI(
+                base_url="https://discourse.canonical.com/",
+                session=session,
+                api_key=DISCOURSE_API_KEY,
+                api_username=DISCOURSE_API_USERNAME,
+            ),
+            index_topic_id=DISCOURSE_INDEX_TOPIC,
+            url_prefix="/guides",
         ),
-        index_topic_id=discourse_index_id,
+        document_template="guides.html",
         url_prefix="/guides",
-    ),
-    document_template="guides.html",
-    url_prefix="/guides",
-)
+    )
+
+    @discourse_docs.blueprint.before_request
+    def before_request():
+        if "openid" not in flask.session:
+            return flask.redirect("/login?next=" + flask.request.path)
+
+    discourse_docs.init_app(app)

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -1,0 +1,73 @@
+import os
+import flask
+import socket
+from django_openid_auth.teams import TeamsRequest, TeamsResponse
+from flask_openid import OpenID
+
+SSO_LOGIN_URL = "https://login.ubuntu.com"
+SSO_TEAM = os.getenv("OPENID_LAUNCHPAD_TEAM", "canonical")
+
+
+def init_sso(app):
+    open_id = OpenID(
+        store_factory=lambda: None,
+        safe_roots=[],
+        extension_responses=[TeamsResponse],
+    )
+
+    @app.route("/login", methods=["GET", "POST"])
+    @open_id.loginhandler
+    def login():
+        if "openid" in flask.session:
+            return flask.redirect(open_id.get_next_url())
+
+        teams_request = TeamsRequest(query_membership=[SSO_TEAM])
+        return open_id.try_login(
+            SSO_LOGIN_URL,
+            ask_for=["email", "fullname"],
+            extensions=[teams_request],
+        )
+
+    @open_id.after_login
+    def after_login(resp):
+        if SSO_TEAM not in resp.extensions["lp"].is_member:
+            flask.abort(403)
+
+        flask.session["openid"] = {
+            "identity_url": resp.identity_url,
+            "email": resp.email,
+            "fullname": resp.fullname,
+        }
+
+        return flask.redirect(open_id.get_next_url())
+
+    @app.route("/logout")
+    def logout():
+        if "openid" in flask.session:
+            flask.session.pop("openid")
+        return flask.redirect("/")
+
+    @app.before_request
+    def before_request():
+        if flask.request.path in ["/login", "/logout"]:
+            return
+        if flask.request.path.startswith("/guides"):
+            if "openid" not in flask.session:
+                return flask.redirect("/login?next=" + flask.request.path)
+
+    @app.after_request
+    def add_headers(response):
+        """
+        Generic rules for headers to add to all requests
+
+        - X-Hostname: Mention the name of the host/pod running the application
+        - Cache-Control: Add cache-control headers for public and private pages
+        """
+
+        response.headers["X-Hostname"] = socket.gethostname()
+
+        if response.status_code == 200:
+            if flask.session:
+                response.headers["Cache-Control"] = "private"
+
+        return response


### PR DESCRIPTION
# Summary

- Add login limited to Canonical org in front of guides
- Update to use discourse.canonical.com guildes instead
- Add K8s configurations to get secrets for discourse docs

# QA

- `dotrun`
- http://0.0.0.0:8104/guides
- Make sure those pages are only accessible if you are logged in
- Make sure all other pages are accessible if you are NOT logged in