### PR TITLE
update practices link to discourse

### DIFF
--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -16,7 +16,7 @@
         <p class="p-card__content">Get the site status deployements</p>
       </div>
       <div class="col-4 p-card--highlighted">
-        <a href="https://canonical-web-and-design.github.io/practices/"> <h3 class="p-card__title">Practices</h3></a>
+        <a href="https://discourse.canonical.com/c/web-and-design-team/coding"> <h3 class="p-card__title">Practices</h3></a>
         <p class="p-card__content">Get the team practices</p>
       </div>
       <div class="col-4 p-card--highlighted">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -16,7 +16,7 @@
         <p class="p-card__content">Get the site status deployements</p>
       </div>
       <div class="col-4 p-card--highlighted">
-        <a href="https://discourse.canonical.com/c/web-and-design-team/coding"> <h3 class="p-card__title">Practices</h3></a>
+        <a href="https://discourse.canonical.com/c/web-and-design-team/7"> <h3 class="p-card__title">Knowledge base (internal)</h3></a>
         <p class="p-card__content">Get the team practices</p>
       </div>
       <div class="col-4 p-card--highlighted">


### PR DESCRIPTION
Replace a dead link to GitHub practices page - https://canonical-web-and-design.github.io/practices/ 
with Canonical Discourse - https://discourse.canonical.com/c/web-and-design-team/coding


