### PR TITLE
Add Design Assembly page

### DIFF
--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -6,7 +6,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h1>Design assembly</h1>
+      <h1>Design Assembly</h1>
     </div>
 
     <div class="col-6">
@@ -29,7 +29,7 @@
       <p>Moderator: <a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
       <p>Topic: <a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
     </div>
-    
+
     <div class="col-6">
       <h2 class="p-muted-heading">Upcoming sessions</h2>
 

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -2,7 +2,6 @@
 
 {% block content %}
 
-{% if page == 1 %}
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
@@ -17,36 +16,37 @@
   </div>
 </section>
 
-<section class="p-strip">
-  <div class="row">
-    <div class="u-fixed-width">
-      <hr>
-    </div>
+{% if page == 1 %}
+  <section class="p-strip">
+    <div class="row">
+      <div class="u-fixed-width">
+        <hr>
+      </div>
 
-    <div class="col-6">
-      <h2 class="p-muted-heading">Next session</h2>
-      <p>{{ future_events[0].human_date }}</p>
-      <p>Moderator: <a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
-      <p>Topic: <a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
-    </div>
+      <div class="col-6">
+        <h2 class="p-muted-heading">Next session</h2>
+        <p>{{ future_events[0].human_date }}</p>
+        <p>Moderator: <a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
+        <p>Topic: <a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
+      </div>
 
-    <div class="col-6">
-      <h2 class="p-muted-heading">Upcoming sessions</h2>
+      <div class="col-6">
+        <h2 class="p-muted-heading">Upcoming sessions</h2>
 
-      <div class="row">
-        {% for i in range(1, 4) %}
-          {% if future_events[i] %}
-            <div class="col-2">
-              <p>{{ future_events[i].human_date }}</p>
-              <p>Moderator: <a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
-              <p>Topic: <a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
-            </div>
-          {% endif %}
-        {% endfor %}
+        <div class="row">
+          {% for i in range(1, 4) %}
+            {% if future_events[i] %}
+              <div class="col-2">
+                <p>{{ future_events[i].human_date }}</p>
+                <p>Moderator: <a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
+                <p>Topic: <a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
+              </div>
+            {% endif %}
+          {% endfor %}
+        </div>
       </div>
     </div>
-  </div>
-</section>
+  </section>
 {% endif %}
 
 {% for event in past_events %}
@@ -78,5 +78,7 @@
     </section>
   {% endif %}
 {% endfor %}
+
+{% include "shared/_pagination.html" %}
 
 {% endblock %}

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -14,14 +14,32 @@
       <p>Everyone is welcome to attend.</p>
     </div>
   </div>
-</div>
+</section>
 
 <section class="p-strip">
   <div class="row">
+    <div class="u-fixed-width">
+      <hr>
+    </div>
+
     <div class="col-6">
       <h2 class="p-muted-heading">Next session</h2>
       <p>{{ future_events[0].human_date }}</p>
       <p>Moderator: <a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
+      <p>Topic: <a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
+    </div>
+    <div class="col-6">
+      <h2 class="p-muted-heading">Upcoming sessions</h2>
+
+      <div class="row">
+        {% for i in range(1, 4) %}
+          <div class="col-2">
+            <p>{{ future_events[i].human_date }}</p>
+            <p>Moderator: <a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
+            <p>Topic: <a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
+          </div>
+        {% endfor %}
+      </div>
     </div>
   </div>
 </section>
@@ -29,12 +47,16 @@
 {% for event in past_events %}
   <section class="p-strip">
     <div class="row">
+      <div class="u-fixed-width">
+        <hr>
+      </div>
+
       <div class="col-6">
         <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay"></iframe>
 
         <p>{{ event.human_date }}</p>
         <p>Moderator: <a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
-
+        
         <p>Topic(s):</p>
         
         {% for topic_provider in event.topic_providers %}
@@ -43,6 +65,7 @@
       </div>
 
       <div class="col-6">
+        <h2 class="p-muted-heading">Agenda</h2>
         <p>{{ event.description | safe }}</p>
       </div>
     </div>

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -29,10 +29,17 @@
         <div class="row">
           <div class="col-2">
             <p class="u-no-margin--bottom">Moderator:</p>
+          </div>
+
+          <div class="col-4">
+            <p class="u-no-margin--bottom"><a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-2">
             <p class="u-no-margin--bottom">Topic:</p>
           </div>
           <div class="col-4">
-            <p class="u-no-margin--bottom"><a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
             <p class="u-no-margin--bottom"><a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
           </div>
         </div>

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -2,6 +2,7 @@
 
 {% block content %}
 
+{% if page == 1 %}
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
@@ -43,33 +44,36 @@
     </div>
   </div>
 </section>
+{% endif %}
 
 {% for event in past_events %}
-  <section class="p-strip">
-    <div class="row">
-      <div class="u-fixed-width">
-        <hr>
-      </div>
+  {% if loop.index >= events_per_page * page - events_per_page + 1 and loop.index <= (page * events_per_page) %}
+    <section class="p-strip">
+      <div class="row">
+        <div class="u-fixed-width">
+          <hr>
+        </div>
 
-      <div class="col-6">
-        <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay"></iframe>
+        <div class="col-6">
+          <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay"></iframe>
 
-        <p>{{ event.human_date }}</p>
-        <p>Moderator: <a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
-        
-        <p>Topic(s):</p>
-        
-        {% for topic_provider in event.topic_providers %}
-          <p><a href="{{ event.topic_provider_links[loop.index0] }}">{{ topic_provider }}</a></p>
-        {% endfor %}
-      </div>
+          <p>{{ event.human_date }}</p>
+          <p>Moderator: <a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
+          
+          <p>Topic(s):</p>
+          
+          {% for topic_provider in event.topic_providers %}
+            <p><a href="{{ event.topic_provider_links[loop.index0] }}">{{ topic_provider }}</a></p>
+          {% endfor %}
+        </div>
 
-      <div class="col-6">
-        <h2 class="p-muted-heading">Agenda</h2>
-        <p>{{ event.description | safe }}</p>
+        <div class="col-6">
+          <h2 class="p-muted-heading">Agenda</h2>
+          <p>{{ event.description | safe }}</p>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
+  {% endif %}
 {% endfor %}
 
 {% endblock %}

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -25,11 +25,18 @@
 
       <div class="col-6">
         <h2 class="p-muted-heading">Next session</h2>
-        <p>{{ future_events[0].human_date }}</p>
-        <p>Moderator:<br /><a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
-        <p>Topic:<br /><a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
+        <p class="is-muted u-no-margin--bottom p-heading--5">{{ future_events[0].human_date }}</p>
+        <div class="row">
+          <div class="col-2">
+            <p class="u-no-margin--bottom">Moderator:</p>
+            <p class="u-no-margin--bottom">Topic:</p>
+          </div>
+          <div class="col-4">
+            <p class="u-no-margin--bottom"><a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
+            <p class="u-no-margin--bottom"><a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
+          </div>
+        </div>
       </div>
-
       <div class="col-6">
         <h2 class="p-muted-heading">Upcoming sessions</h2>
 
@@ -37,9 +44,11 @@
           {% for i in range(1, 4) %}
             {% if future_events[i] %}
               <div class="col-2">
-                <p>{{ future_events[i].human_date }}</p>
-                <p>Moderator:<br /><a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
-                <p>Topic:<br /><a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
+                <div>
+                  <p class="is-muted u-no-margin--bottom p-heading--5">{{ future_events[i].human_date }}</p>
+                </div>
+                <p class="u-no-margin--bottom">Moderator:<br /><a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
+                <p class="u-no-margin--bottom">Topic:<br /><a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
               </div>
             {% endif %}
           {% endfor %}
@@ -58,19 +67,25 @@
         </div>
 
         <div class="col-6">
-          <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay" style="margin-top: 5px;"></iframe>
-
-          <p>{{ event.human_date }}</p>
-          <p>Moderator:<br /><a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
-          
-          <p>Topic:<br />
-          
-          {% for topic_provider in event.topic_providers %}
-            <a href="{{ event.topic_provider_links[loop.index0] }}">{{ topic_provider }}</a><br />
-          {% endfor %}
-          </p>
+          <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay" style="margin: .5rem 0"></iframe>
+          <p class="is-muted u-no-margin--bottom p-heading--5">{{ event.human_date }}</p>
+          <div class="row">
+            <div class="col-2">
+              <p class="u-no-margin--bottom">Moderator:</p>
+            </div>
+            <div class="col-4">
+              <p class="u-no-margin--bottom"><a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-2">
+              <p class="u-no-margin--bottom">Topic:</p>
+            </div>
+            <div class="col-4">
+              <p class="u-no-margin--bottom"> {% for topic_provider in event.topic_providers %} <a href="{{ event.topic_provider_links[loop.index0] }}">{{ topic_provider }}</a>{% endfor %}</p>
+            </div>
+          </div>
         </div>
-
         <div class="col-6">
           <h2 class="p-muted-heading">Agenda</h2>
           <p>{{ event.description | safe }}</p>

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h1>Design assembly</h1>
+    </div>
+
+    <div class="col-6">
+      <p>A meeting dedicated to the whole design team: share topics and discoveries, ask for help and feedback, work together and show & tell.</p>
+
+      <p>Everyone is welcome to attend.</p>
+    </div>
+  </div>
+</div>
+
+<section class="p-strip">
+  <div class="row">
+    <div class="col-6">
+      <h2 class="p-muted-heading">Next session</h2>
+      <p>{{ future_events[0].human_date }}</p>
+      <p>Moderator: <a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
+    </div>
+  </div>
+</section>
+
+{% for event in past_events %}
+  <section class="p-strip">
+    <div class="row">
+      <div class="col-6">
+        <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay"></iframe>
+
+        <p>{{ event.human_date }}</p>
+        <p>Moderator: <a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
+
+        <p>Topic(s):</p>
+        
+        {% for topic_provider in event.topic_providers %}
+          <p><a href="{{ event.topic_provider_links[loop.index0] }}">{{ topic_provider }}</a></p>
+        {% endfor %}
+      </div>
+
+      <div class="col-6">
+        <p>{{ event.description | safe }}</p>
+      </div>
+    </div>
+  </section>
+{% endfor %}
+
+{% endblock %}

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -29,16 +29,19 @@
       <p>Moderator: <a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
       <p>Topic: <a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
     </div>
+    
     <div class="col-6">
       <h2 class="p-muted-heading">Upcoming sessions</h2>
 
       <div class="row">
         {% for i in range(1, 4) %}
-          <div class="col-2">
-            <p>{{ future_events[i].human_date }}</p>
-            <p>Moderator: <a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
-            <p>Topic: <a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
-          </div>
+          {% if future_events[i] %}
+            <div class="col-2">
+              <p>{{ future_events[i].human_date }}</p>
+              <p>Moderator: <a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
+              <p>Topic: <a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
+            </div>
+          {% endif %}
         {% endfor %}
       </div>
     </div>

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -26,8 +26,8 @@
       <div class="col-6">
         <h2 class="p-muted-heading">Next session</h2>
         <p>{{ future_events[0].human_date }}</p>
-        <p>Moderator: <a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
-        <p>Topic: <a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
+        <p>Moderator:<br /><a href="{{ future_events[0].moderator_profile_link }}">{{ future_events[0].moderator }}</a></p>
+        <p>Topic:<br /><a href="{{ future_events[0].topic_provider_links[0] }}">{{ future_events[0].topic_providers[0] }}</a></p>
       </div>
 
       <div class="col-6">
@@ -38,8 +38,8 @@
             {% if future_events[i] %}
               <div class="col-2">
                 <p>{{ future_events[i].human_date }}</p>
-                <p>Moderator: <a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
-                <p>Topic: <a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
+                <p>Moderator:<br /><a href="{{ future_events[i].moderator_profile_link }}">{{ future_events[i].moderator }}</a></p>
+                <p>Topic:<br /><a href="{{ future_events[i].topic_provider_links[0] }}">{{ future_events[i].topic_providers[0] }}</a></p>
               </div>
             {% endif %}
           {% endfor %}
@@ -58,16 +58,17 @@
         </div>
 
         <div class="col-6">
-          <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay"></iframe>
+          <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay" style="margin-top: 5px;"></iframe>
 
           <p>{{ event.human_date }}</p>
-          <p>Moderator: <a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
+          <p>Moderator:<br /><a href="{{ event.moderator_profile_link }}">{{ event.moderator }}</a></p>
           
-          <p>Topic(s):</p>
+          <p>Topic:<br />
           
           {% for topic_provider in event.topic_providers %}
-            <p><a href="{{ event.topic_provider_links[loop.index0] }}">{{ topic_provider }}</a></p>
+            <a href="{{ event.topic_provider_links[loop.index0] }}">{{ topic_provider }}</a><br />
           {% endfor %}
+          </p>
         </div>
 
         <div class="col-6">

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -74,7 +74,9 @@
         </div>
 
         <div class="col-6">
+          {% if event.video %}
           <iframe src="{{ event.video }}" width="640" height="360" allow="autoplay" style="margin: .5rem 0"></iframe>
+          {% endif %}
           <p class="is-muted u-no-margin--bottom p-heading--5">{{ event.human_date }}</p>
           <div class="row">
             <div class="col-2">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -67,6 +67,10 @@
         <a href="/canonicool"> <h3 class="p-card__title">Canonicool sessions</h3></a>
         <p class="p-card__content">A list of past, present and future Canonicool sessions</p>
       </div>
+      <div class="col-4 p-card--highlighted">
+        <a href="/design-assembly"> <h3 class="p-card__title">Design Assembly</h3></a>
+        <p class="p-card__content">Details on upcoming Design Assembly meetings, as well as recordings and notes for previous meetings</p>
+      </div>
     </div>
   </section>
 {% endblock content %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -2,6 +2,7 @@ import flask
 from canonicalwebteam.flask_base.app import FlaskBase
 
 from webapp.canonicool import canonicool
+from webapp.design_assembly import design_assembly
 from webapp.guides import bootstrap_guides
 from webapp.practices import bootstrap_practices
 from webapp.releases import releases
@@ -24,6 +25,7 @@ def index():
 app.register_blueprint(webteam, url_prefix="/team")
 app.register_blueprint(releases, url_prefix="/releases")
 app.register_blueprint(canonicool, url_prefix="/canonicool")
+app.register_blueprint(design_assembly, url_prefix="/design-assembly")
 bootstrap_guides(app)
 bootstrap_practices(app)
 init_sso(app)

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -11,8 +11,8 @@ from webapp.sso import login_required
 DEPLOYMENT_ID = os.getenv(
     "DEPLOYMENT_ID",
     (
-        "AKfycbyMHB6E0ErhpuO2Om1UsZ6gveh3oADt0gjp_"
-        "IJoFUqoEUYCtS0sJ4mRnlfYNQ26ynG4PA"
+        "AKfycbzCwEE2_l7oUdsU3BJON99KHtDL0o"
+        "fLVIhhjsNThscoP_m52MpkumwLrk00dPaHajopDA"
     ),
 )
 DESIGN_ASSEMBLY_SHEET_URL = (

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -50,7 +50,7 @@ def index():
         elif today <= event_date:
             future_events.append(event)
 
-    events_per_page = 6
+    events_per_page = 3
     return render_template(
         "design-assembly.html",
         past_events=past_events,

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -8,7 +8,10 @@ from flask import Blueprint, render_template, request
 
 DEPLOYMENT_ID = os.getenv(
     "DEPLOYMENT_ID",
-    "AKfycbyMHB6E0ErhpuO2Om1UsZ6gveh3oADt0gjp_IJoFUqoEUYCtS0sJ4mRnlfYNQ26ynG4PA",
+    (
+        "AKfycbyMHB6E0ErhpuO2Om1UsZ6gveh3oADt0gjp_"
+        "IJoFUqoEUYCtS0sJ4mRnlfYNQ26ynG4PA"
+    ),
 )
 DESIGN_ASSEMBLY_SHEET_URL = (
     f"https://script.google.com/macros/s/{DEPLOYMENT_ID}/exec"

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -32,7 +32,6 @@ def hash_email(email):
 
 
 @design_assembly.route("/")
-# @login_required
 def index():
     page = request.args.get("page", default=1, type=int)
     response = requests.get(DESIGN_ASSEMBLY_SHEET_URL)

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -6,6 +6,8 @@ from datetime import datetime, timedelta
 from dateutil import parser
 from flask import Blueprint, render_template, request
 
+from webapp.sso import login_required
+
 DEPLOYMENT_ID = os.getenv(
     "DEPLOYMENT_ID",
     (
@@ -30,6 +32,7 @@ def hash_email(email):
 
 
 @design_assembly.route("/")
+@login_required
 def index():
     page = request.args.get("page", default=1, type=int)
     response = requests.get(DESIGN_ASSEMBLY_SHEET_URL)

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -1,0 +1,61 @@
+import requests
+import os
+import hashlib
+
+from datetime import datetime, timedelta
+from dateutil import parser
+from flask import Blueprint, render_template, request
+
+DEPLOYMENT_ID = os.getenv(
+    "DEPLOYMENT_ID",
+    "AKfycbzcp6ipwy0WKmoZpOcQjnsIAWlZzSOrR2b92lqBLoyjxjNMnqUDCFf_IQlfEfI5GS5nkA",
+)
+DESIGN_ASSEMBLY_SHEET_URL = (
+    f"https://script.google.com/macros/s/{DEPLOYMENT_ID}/exec"
+)
+
+design_assembly = Blueprint(
+    "design_assembly",
+    __name__,
+    template_folder="/templates",
+    static_folder="/static",
+)
+
+
+def hash_email(email):
+    return hashlib.md5(email.encode("utf-8")).hexdigest()
+
+
+@design_assembly.route("/")
+def index():
+    page = request.args.get("page", default=1, type=int)
+    response = requests.get(DESIGN_ASSEMBLY_SHEET_URL)
+
+    future_events = []
+    past_events = []
+
+    today = datetime.today().date()
+
+    for event in response.json():
+        hour = timedelta(hours=1)
+        # for some reason the date is coming through as 11pm the previous day
+        # of the date given in the spreadsheet, so we add an hour to get the
+        # correct date
+        corrected_datetime = parser.parse(event["date"]) + hour
+        event_date = corrected_datetime.date()
+        event["human_date"] = event_date.strftime("%m/%d/%Y")
+
+        if today > event_date:
+            past_events.insert(0, event)
+        elif today <= event_date:
+            future_events.append(event)
+
+    events_per_page = 6
+    return render_template(
+        "design-assembly.html",
+        past_events=past_events,
+        future_events=future_events,
+        page=page,
+        total_pages=len(past_events) / events_per_page,
+        events_per_page=events_per_page,
+    )

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from dateutil import parser
 from flask import Blueprint, render_template, request
 
-from webapp.sso import login_required
+# from webapp.sso import login_required
 
 DEPLOYMENT_ID = os.getenv(
     "DEPLOYMENT_ID",
@@ -32,7 +32,7 @@ def hash_email(email):
 
 
 @design_assembly.route("/")
-@login_required
+# @login_required
 def index():
     page = request.args.get("page", default=1, type=int)
     response = requests.get(DESIGN_ASSEMBLY_SHEET_URL)

--- a/webapp/design_assembly.py
+++ b/webapp/design_assembly.py
@@ -8,7 +8,7 @@ from flask import Blueprint, render_template, request
 
 DEPLOYMENT_ID = os.getenv(
     "DEPLOYMENT_ID",
-    "AKfycbzcp6ipwy0WKmoZpOcQjnsIAWlZzSOrR2b92lqBLoyjxjNMnqUDCFf_IQlfEfI5GS5nkA",
+    "AKfycbyMHB6E0ErhpuO2Om1UsZ6gveh3oADt0gjp_IJoFUqoEUYCtS0sJ4mRnlfYNQ26ynG4PA",
 )
 DESIGN_ASSEMBLY_SHEET_URL = (
     f"https://script.google.com/macros/s/{DEPLOYMENT_ID}/exec"
@@ -43,7 +43,7 @@ def index():
         # correct date
         corrected_datetime = parser.parse(event["date"]) + hour
         event_date = corrected_datetime.date()
-        event["human_date"] = event_date.strftime("%m/%d/%Y")
+        event["human_date"] = event_date.strftime("%d/%m/%Y")
 
         if today > event_date:
             past_events.insert(0, event)

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -51,7 +51,7 @@ def init_sso(app):
         if flask.request.path in ["/login", "/logout"]:
             return
         if "openid" not in flask.session and flask.request.path.startswith(
-            ("/guides", "/practices")
+            ("/guides", "/practices", "/design-assembly")
         ):
             return flask.redirect("/login?next=" + flask.request.path)
 
@@ -71,19 +71,3 @@ def init_sso(app):
                 response.headers["Cache-Control"] = "private"
 
         return response
-
-
-def login_required(func):
-    """
-    Decorator that checks if a user is logged in, and redirects
-    to login page if not.
-    """
-
-    @functools.wraps(func)
-    def is_user_logged_in(*args, **kwargs):
-        if "openid" not in flask.session:
-            return flask.redirect("/login?next=" + flask.request.path)
-
-        return func(*args, **kwargs)
-
-    return is_user_logged_in

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -71,3 +71,19 @@ def init_sso(app):
                 response.headers["Cache-Control"] = "private"
 
         return response
+
+
+def login_required(func):
+    """
+    Decorator that checks if a user is logged in, and redirects
+    to login page if not.
+    """
+
+    @functools.wraps(func)
+    def is_user_logged_in(*args, **kwargs):
+        if "openid" not in flask.session:
+            return flask.redirect("/login?next=" + flask.request.path)
+
+        return func(*args, **kwargs)
+
+    return is_user_logged_in


### PR DESCRIPTION
## Done
- Added /design-assembly page
  - Added SSO
- Added link to /design-assembly on the homepage

## QA
- Visit https://webteam-canonical-com-93.demos.haus/ in a private browser
- Click the link on the "Design Assembly" card item
- You should be prompted to sign in with SSO
- When signed in, you should be redirected to /design-assembly
- The page should:
  - match the [design](https://www.figma.com/file/VSSGYamoulKk7sOwNfu21m/Hackaton%3A-Design-Assembly?node-id=0%3A1)
  - have working pagination
  - include links to colleague's directory profile when they're listed under "Moderator" or "Topic"