### PR TITLE
Switch SSO auth team to "canonical" for company-wide access

### DIFF
--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -4,7 +4,7 @@ from django_openid_auth.teams import TeamsRequest, TeamsResponse
 from flask_openid import OpenID
 
 SSO_LOGIN_URL = "https://login.ubuntu.com"
-SSO_TEAM = "canonical-webmonkeys"
+SSO_TEAM = "canonical"
 
 
 def init_sso(app):


### PR DESCRIPTION
If you go to https://webteam-canonical-com-101.demos.haus/guides, you'll notice that you get "forbidden". This is because we need special permission to use the private "canonical" group. Which I'm trying to procure.