### PR TITLE
add document title for each page

### DIFF
--- a/templates/canonicool.html
+++ b/templates/canonicool.html
@@ -4,7 +4,7 @@
 {% if page == 1 %}
 <section class="p-strip--suru-blog-header is-deep">
   <div class="u-fixed-width">
-    <h1 class="u-sv2">Canonicool sessions</h1>
+    <h1 class="u-sv2">{% block title %}Canonicool sessions{% endblock %}</h1>
   </div>
   <div class="row">
     <div class="col-5">

--- a/templates/design-assembly.html
+++ b/templates/design-assembly.html
@@ -5,7 +5,7 @@
 <section class="p-strip">
   <div class="row">
     <div class="col-6">
-      <h1>Design Assembly</h1>
+      <h1>{% block title %}Design Assembly{% endblock %}</h1>
     </div>
 
     <div class="col-6">

--- a/templates/masterclasses.html
+++ b/templates/masterclasses.html
@@ -3,7 +3,7 @@
 {% block content %}
 <section class="p-strip--suru">
   <div class="u-fixed-width">
-    <h1>Masterclasses</h1>
+    <h1>{% block title %}Masterclasses{% endblock %}</h1>
   </div>
 </section>
 


### PR DESCRIPTION
- fix: some pages have a missing title and display the same, generic "Web & design portal" instead
